### PR TITLE
FIX: fix jekyll build error: plugins and layouts should be plugins_dir and layouts_dir

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,8 +5,8 @@
 # Where things are
 source:       .
 destination:  ./_site
-plugins:      ./_plugins
-layouts:      ./_layouts
+plugins_dir:  ./_plugins
+layouts_dir:  ./_layouts
 paginate:     8
 
 # Handling Reading


### PR DESCRIPTION
fix #48 